### PR TITLE
Remove career meetup banner from layout

### DIFF
--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -1,13 +1,11 @@
 <script>
     import Navbar from '$lib/components/Navbar.svelte';
     import Footer from '$lib/components/Footer.svelte';
-    import CountdownBanner from '$lib/components/CountdownBanner.svelte';
     import { updated } from '$app/state';
     let { children } = $props();
 
 </script>
   
-  <CountdownBanner />
   <Navbar />
   
   <main data-sveltekit-reload={updated.current ? '' : 'off'}>
@@ -23,7 +21,7 @@
   }
   
   :global(.navbar) {
-    top: 72px !important;
+    top: 0 !important;
     z-index: 1000 !important;
   }
   
@@ -37,7 +35,7 @@
   }
   
   :global(main) {
-    padding-top: 135px;
+    padding-top: 63px;
   }
   
   :global(.primary-button) {


### PR DESCRIPTION
- Remove CountdownBanner component import and usage
- Adjust navbar positioning from top: 72px to top: 0
- Reduce main content padding from 135px to 63px

🤖 Generated with [Claude Code](https://claude.com/claude-code)